### PR TITLE
DAG Viewer: Interactive visualization tool for T.A.S.K.S files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,36 @@
+# Git LFS tracking for images
+*.png filter=lfs diff=lfs merge=lfs -text
+*.jpg filter=lfs diff=lfs merge=lfs -text
+*.jpeg filter=lfs diff=lfs merge=lfs -text
+*.gif filter=lfs diff=lfs merge=lfs -text
+*.bmp filter=lfs diff=lfs merge=lfs -text
+*.svg filter=lfs diff=lfs merge=lfs -text
+*.webp filter=lfs diff=lfs merge=lfs -text
+*.ico filter=lfs diff=lfs merge=lfs -text
+
+# Video files
+*.mp4 filter=lfs diff=lfs merge=lfs -text
+*.avi filter=lfs diff=lfs merge=lfs -text
+*.mov filter=lfs diff=lfs merge=lfs -text
+*.webm filter=lfs diff=lfs merge=lfs -text
+
+# Audio files
+*.mp3 filter=lfs diff=lfs merge=lfs -text
+*.wav filter=lfs diff=lfs merge=lfs -text
+*.ogg filter=lfs diff=lfs merge=lfs -text
+
+# Archive files
+*.zip filter=lfs diff=lfs merge=lfs -text
+*.tar filter=lfs diff=lfs merge=lfs -text
+*.gz filter=lfs diff=lfs merge=lfs -text
+*.7z filter=lfs diff=lfs merge=lfs -text
+*.rar filter=lfs diff=lfs merge=lfs -text
+
+# Binary documents
+*.pdf filter=lfs diff=lfs merge=lfs -text
+*.doc filter=lfs diff=lfs merge=lfs -text
+*.docx filter=lfs diff=lfs merge=lfs -text
+*.xls filter=lfs diff=lfs merge=lfs -text
+*.xlsx filter=lfs diff=lfs merge=lfs -text
+*.ppt filter=lfs diff=lfs merge=lfs -text
+*.pptx filter=lfs diff=lfs merge=lfs -text

--- a/tools/dag-viewer/.gitattributes
+++ b/tools/dag-viewer/.gitattributes
@@ -1,0 +1,1 @@
+tools/dag-viewer/example.png filter=lfs diff=lfs merge=lfs -text

--- a/tools/dag-viewer/README.md
+++ b/tools/dag-viewer/README.md
@@ -2,6 +2,8 @@
 
 A command-line tool that generates interactive DAG (Directed Acyclic Graph) visualizations from T.A.S.K.S specification JSON files. Designed for LLM invocation with structured JSON output.
 
+![DAG Viewer Example](./example.png)
+
 ## Overview
 
 The DAG Viewer transforms T.A.S.K.S project planning data (tasks, features, dependencies, and waves) into an interactive HTML visualization using the dagre layout algorithm and D3.js for rendering. The output is a standalone HTML file that can be viewed in any modern web browser without requiring a server.

--- a/tools/dag-viewer/example.png
+++ b/tools/dag-viewer/example.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:52cff136a4beac8d8eaadae0f17bc0c3a7602332b40c26547878e7ea97cac01a
+size 231897

--- a/tools/dag-viewer/src/htmlGeneratorCytoscape.js
+++ b/tools/dag-viewer/src/htmlGeneratorCytoscape.js
@@ -446,14 +446,16 @@ export default class HTMLGeneratorCytoscape {
                         selector: 'edge',
                         style: {
                             'width': 2,
-                            'line-color': data => {
-                                if (data.confidenceLevel === 'high') return '#22c55e';
-                                if (data.confidenceLevel === 'medium') return '#f97316';
+                            'line-color': function(ele) {
+                                const level = ele.data('confidenceLevel');
+                                if (level === 'high') return '#22c55e';
+                                if (level === 'medium') return '#f97316';
                                 return '#ef4444';
                             },
-                            'target-arrow-color': data => {
-                                if (data.confidenceLevel === 'high') return '#22c55e';
-                                if (data.confidenceLevel === 'medium') return '#f97316';
+                            'target-arrow-color': function(ele) {
+                                const level = ele.data('confidenceLevel');
+                                if (level === 'high') return '#22c55e';
+                                if (level === 'medium') return '#f97316';
                                 return '#ef4444';
                             },
                             'target-arrow-shape': 'triangle',


### PR DESCRIPTION
## Summary
- Created a comprehensive DAG visualization tool for T.A.S.K.S JSON files
- Implemented modern UI with Cytoscape.js Canvas-based rendering (replaced D3/SVG)
- Fixed critical edge color confidence mapping bug

## Features
- **Interactive Graph Visualization**: Pan, zoom, and click nodes for details
- **Advanced Filtering**: Search by text, filter by feature/wave with active badges
- **Modern UI**: Shadcn-inspired design with dark mode support
- **Multiple Renderers**: Classic, Modern, and Cytoscape options
- **Edge Information**: Click edges to see dependency details
- **Humanized Durations**: Shows "2hr 5m" instead of decimals
- **Git LFS Support**: Configured for binary files and images

## Bug Fixes
- Fixed edge colors not mapping correctly to confidence levels
- Fixed wave dropdown not populating
- Fixed node selection highlighting

## Test Plan
- [ ] Run `npm run example` to generate example visualization
- [ ] Test filtering by feature and wave
- [ ] Verify edge colors match legend (high=green, medium=orange, low=red)
- [ ] Click nodes and edges to test details panel
- [ ] Test dark mode toggle
- [ ] Verify screenshot displays correctly in README

🤖 Generated with [Claude Code](https://claude.ai/code)